### PR TITLE
Github maven repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI pipeline
 
 on:
   push:
-    branches: [main]
+    branches:
+      - master
   pull_request:
-    branches: [main]
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build and test code
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "maven"
+
+      - name: Build and test code with Maven
+        run: mvn -B package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
         run: mvn -B versions:set -DremoveSnapshot -DgenerateBackupPoms=false
 
       - name: Build and publish release package
-        run: mvn -B deploy -Dmaven.resolver.transport=wagon
+        run: mvn -B deploy -Dmaven.resolver.transport=wagon -DtargetRepo=triforkGithubMavenRepo
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Build and publish release to GitHub Packages
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "maven"
+
+      - name: Remove snapshot from version in Maven
+        run: mvn -B versions:set -DremoveSnapshot -DgenerateBackupPoms=false
+
+      - name: Build and publish release package
+        run: mvn -B deploy -Dmaven.resolver.transport=wagon
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,6 @@
     </repository>
   </repositories>
 
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/trifork/unsealed-ci</url>
-    </repository>
-  </distributionManagement>
-
   <scm>
     <connection>scm:git:git@github.com:trifork/unsealed.git</connection>
     <url>scm:git:git@github.com:trifork/unsealed.git</url>
@@ -90,4 +82,46 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>triforkGithubMavenRepo</id>
+      <activation>
+        <property>
+          <name>targetRepo</name>
+          <value>triforkGithubMavenRepo</value>
+        </property>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>github</id>
+          <name>GitHub Packages</name>
+          <url>https://maven.pkg.github.com/trifork/unsealed-ci</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+    <profile>
+      <id>fmkNeticMavenRepo</id>
+      <activation>
+        <property>
+          <name>targetRepo</name>
+          <value>fmkNeticMavenRepo</value>
+        </property>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>trifork.releases</id>
+          <name>Trifork Releases</name>
+          <url>https://ci.fmk.netic.dk/nexus/content/repositories/releases/</url>
+          <layout>default</layout>
+        </repository>
+        <snapshotRepository>
+          <id>trifork.snapshots</id>
+          <name>Trifork Snapshots</name>
+          <url>https://ci.fmk.netic.dk/nexus/content/repositories/snapshots/</url>
+          <layout>default</layout>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,97 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.trifork.unsealed</groupId>
-    <artifactId>unsealed</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
-    <packaging>jar</packaging>
+  <groupId>com.trifork.unsealed</groupId>
+  <artifactId>unsealed</artifactId>
+  <version>1.0.10-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-    <name>unsealed</name>
-    <description>This is a description</description>
+  <name>unsealed</name>
+  <description>This is a description</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
-    </properties>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
-    <repositories>
-        <repository>
-            <id>mvnrepository.com</id>
-            <name>mvnrepository.com</name>
-            <url>https://mvnrepository.com/artifact</url>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <id>mvnrepository.com</id>
+      <name>mvnrepository.com</name>
+      <url>https://mvnrepository.com/artifact</url>
+    </repository>
+  </repositories>
 
-    <distributionManagement>
-        <repository>
-            <id>trifork.releases</id>
-            <name>Trifork Releases</name>
-            <url>https://ci.fmk.netic.dk/nexus/content/repositories/releases/</url>
-            <layout>default</layout>
-        </repository>
-        <snapshotRepository>
-            <id>trifork.snapshots</id>
-            <name>Trifork Snapshots</name>
-            <url>https://ci.fmk.netic.dk/nexus/content/repositories/snapshots/</url>
-            <layout>default</layout>
-        </snapshotRepository>
-    </distributionManagement>
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/trifork/unsealed-ci</url>
+    </repository>
+  </distributionManagement>
 
-    <scm>
-        <connection>scm:git:git@github.com:trifork/unsealed.git</connection>
-        <url>scm:git:git@github.com:trifork/unsealed.git</url>
-        <developerConnection>scm:git:git@github.com:trifork/unsealed.git</developerConnection>
-        <tag>websecurity-1.22</tag>
-    </scm>
+  <scm>
+    <connection>scm:git:git@github.com:trifork/unsealed.git</connection>
+    <url>scm:git:git@github.com:trifork/unsealed.git</url>
+    <developerConnection>scm:git:git@github.com:trifork/unsealed.git</developerConnection>
+    <tag>websecurity-1.22</tag>
+  </scm>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <!--  https://stackoverflow.com/questions/15166781/mvn-releaseprepare-not-committing-changes-to-pom-xml -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.scm</groupId>
-                            <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.8.1</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <!--
+          https://stackoverflow.com/questions/15166781/mvn-releaseprepare-not-committing-changes-to-pom-xml -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.scm</groupId>
+              <artifactId>maven-scm-provider-gitexe</artifactId>
+              <version>1.8.1</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
 
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <release>11</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
-            </plugin>
-        </plugins>
-    </build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+      </plugin>
+    </plugins>
+  </build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.6.1</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.6.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
Hej Jeppe.
Jeg kan se, at der allerede findes et maven repository sat i unsealed til fmk's netic, men er der nogen der trækker unsealed derfra i øjeblikket?
Jeg har lavet en fork der smider det op på triforks github maven repo, hvor vi også trækker sosi-ws-pure fra.
Kan vi skifte til det, eller alternativt hoste det to steder? Og hvad siger du til at have et realease-flow som det i denne PR? Det er stjålet fra sosi-ws-pure.

Jeg har i øvrigt fået unsealed integreret i vores dgws-client - det virker rigtigt godt og var meget nemt, må jeg sige!

Lad mig høre hvad du tænker.